### PR TITLE
bug: fix type_of_volume to output  name attribute

### DIFF
--- a/pyfi_util/pyfish_util.py
+++ b/pyfi_util/pyfish_util.py
@@ -919,7 +919,7 @@ def scan_for_files(
                                         "timestamp": timestamp,
                                         "filetype": file_type[0],
                                         "inode": file_inode,
-                                        "type_of_volume": f"{type_of_volume}",
+                                        "type_of_volume": f"{type_of_volume.name}",
                                     }
                                 )
                             if sync_to_s3:
@@ -970,7 +970,7 @@ def scan_for_files(
                                             timestamp,
                                             file_type[0],
                                             file_inode,
-                                            f"{type_of_volume}",
+                                            f"{type_of_volume.name}",
                                             volume_name,
                                         )
                                     )


### PR DESCRIPTION
Simple change to the type_of_volume, using the name field.  Decided to use just name, and not type_of_volme.__dict__ to make it more simple. Seems perfectly usable like that for now. Assumption made that type_of_volume will not change over time.  Perhaps get added to, but the basic info is pretty static